### PR TITLE
WIP: Update miniz_oxide to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
-flate2 = { version = "1.0.0", default-features = false, optional = true }
 miniz_oxide = { version = "0.4.1", default-features = false, optional = true, features = ["no_extern_crate_alloc"] }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"
@@ -27,9 +26,7 @@ rand = "0.7"
 walkdir = "2"
 
 [features]
-deflate = ["flate2/rust_backend"]
-deflate-miniz = ["flate2/default"]
-deflate-zlib = ["flate2/zlib"]
+deflate = ["miniz_oxide"]
 default = ["bzip2", "deflate", "time"]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
-# FIXME(#170): flate2 1.0.15 has an MSRV of 1.36.0, breaking ours. We'll update when we know if this will be addressed
-flate2 = { version = ">=1.0.0, <=1.0.14", default-features = false, optional = true }
+flate2 = { version = "1.0.0", default-features = false, optional = true }
+miniz_oxide = { version = "0.4.1", default-features = false, optional = true, features = ["no_extern_crate_alloc"] }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"
 bzip2 = { version = "0.3", optional = true }


### PR DESCRIPTION
Closes #170 

The `no_extern_crate_alloc` has been published! Woop 🎉 

Rust dependency features can get weird, but I'm pretty sure this does the trick. `flate2` should compile with the latest version that can build with `miniz_oxide` 0.4.x, which (assuming they play nice with semver) should always have a `no_extern_crate_alloc` feature.

Edit: ack... `flate2` is going to need no-alloc support. Might still be waiting