### PR TITLE
Reintroduce Path Sanitization

### DIFF
--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -18,7 +18,7 @@ fn real_main() -> i32 {
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
-        let outpath = match file.name_as_child() {
+        let outpath = match file.enclosed_name() {
             Some(path) => path.to_owned(),
             None => continue,
         };

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -18,8 +18,10 @@ fn real_main() -> i32 {
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
-        #[allow(deprecated)]
-        let outpath = file.sanitized_name();
+        let outpath = match file.name_as_child() {
+            Some(path) => path,
+            None => continue,
+        };
 
         {
             let comment = file.comment();
@@ -29,17 +31,13 @@ fn real_main() -> i32 {
         }
 
         if (&*file.name()).ends_with('/') {
-            println!(
-                "File {} extracted to \"{}\"",
-                i,
-                outpath.as_path().display()
-            );
+            println!("File {} extracted to \"{}\"", i, outpath.display());
             fs::create_dir_all(&outpath).unwrap();
         } else {
             println!(
                 "File {} extracted to \"{}\" ({} bytes)",
                 i,
-                outpath.as_path().display(),
+                outpath.display(),
                 file.size()
             );
             if let Some(p) = outpath.parent() {

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -19,7 +19,7 @@ fn real_main() -> i32 {
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
         let outpath = match file.name_as_child() {
-            Some(path) => path,
+            Some(path) => path.to_owned(),
             None => continue,
         };
 

--- a/examples/file_info.rs
+++ b/examples/file_info.rs
@@ -19,8 +19,13 @@ fn real_main() -> i32 {
 
     for i in 0..archive.len() {
         let file = archive.by_index(i).unwrap();
-        #[allow(deprecated)]
-        let outpath = file.sanitized_name();
+        let outpath = match file.name_as_child() {
+            Some(path) => path,
+            None => {
+                println!("Entry {} has a suspicious path", file.name());
+                continue;
+            }
+        };
 
         {
             let comment = file.comment();
@@ -33,13 +38,13 @@ fn real_main() -> i32 {
             println!(
                 "Entry {} is a directory with name \"{}\"",
                 i,
-                outpath.as_path().display()
+                outpath.display()
             );
         } else {
             println!(
                 "Entry {} is a file with name \"{}\" ({} bytes)",
                 i,
-                outpath.as_path().display(),
+                outpath.display(),
                 file.size()
             );
         }

--- a/examples/file_info.rs
+++ b/examples/file_info.rs
@@ -19,7 +19,7 @@ fn real_main() -> i32 {
 
     for i in 0..archive.len() {
         let file = archive.by_index(i).unwrap();
-        let outpath = match file.name_as_child() {
+        let outpath = match file.enclosed_name() {
             Some(path) => path,
             None => {
                 println!("Entry {} has a suspicious path", file.name());

--- a/src/read.rs
+++ b/src/read.rs
@@ -311,6 +311,49 @@ impl<R: Read + io::Seek> ZipArchive<R> {
             comment: footer.zip_file_comment,
         })
     }
+    /// Extract a Zip archive into a directory.
+    ///
+    /// Malformed and malicious paths are rejected so that they cannot escape
+    /// the given directory.
+    ///
+    /// This bails on the first error and does not attempt cleanup.
+    ///
+    /// # Platform-specific behaviour
+    ///
+    /// On unix systems permissions from the zip file are preserved, if they exist.
+    pub fn extract<P: AsRef<Path>>(&mut self, directory: P) -> ZipResult<()> {
+        use std::fs;
+
+        for i in 0..self.len() {
+            let mut file = self.by_index(i)?;
+            let filepath = file
+                .name_as_child()
+                .ok_or(ZipError::InvalidArchive("Invalid file path"))?;
+
+            let outpath = directory.as_ref().join(filepath);
+
+            if (file.name()).ends_with('/') {
+                fs::create_dir_all(&outpath)?;
+            } else {
+                if let Some(p) = outpath.parent() {
+                    if !p.exists() {
+                        fs::create_dir_all(&p)?;
+                    }
+                }
+                let mut outfile = fs::File::create(&outpath)?;
+                io::copy(&mut file, &mut outfile)?;
+            }
+            // Get and Set permissions
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Some(mode) = file.unix_mode() {
+                    fs::set_permissions(&outpath, fs::Permissions::from_mode(mode))?;
+                }
+            }
+        }
+        Ok(())
+    }
 
     /// Number of files contained in this zip.
     pub fn len(&self) -> usize {
@@ -967,8 +1010,7 @@ mod test {
 
         for i in 0..zip.len() {
             let zip_file = zip.by_index(i).unwrap();
-            #[allow(deprecated)]
-            let full_name = zip_file.sanitized_name();
+            let full_name = zip_file.name_as_child().unwrap();
             let file_name = full_name.file_name().unwrap().to_str().unwrap();
             assert!(
                 (file_name.starts_with("dir") && zip_file.is_dir())

--- a/tests/zip64_large.rs
+++ b/tests/zip64_large.rs
@@ -195,7 +195,7 @@ fn zip64_large() {
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
-        let outpath = file.name_as_child().unwrap();
+        let outpath = file.enclosed_name().unwrap();
         println!(
             "Entry {} has name \"{}\" ({} bytes)",
             i,

--- a/tests/zip64_large.rs
+++ b/tests/zip64_large.rs
@@ -195,12 +195,11 @@ fn zip64_large() {
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).unwrap();
-        #[allow(deprecated)]
-        let outpath = file.sanitized_name();
+        let outpath = file.name_as_child().unwrap();
         println!(
             "Entry {} has name \"{}\" ({} bytes)",
             i,
-            outpath.as_path().display(),
+            outpath.display(),
             file.size()
         );
 

--- a/tests/zip_crypto.rs
+++ b/tests/zip_crypto.rs
@@ -75,8 +75,7 @@ fn encrypted_file() {
             .by_index_decrypt(0, "test".as_bytes())
             .unwrap()
             .unwrap();
-        #[allow(deprecated)]
-        let file_name = file.sanitized_name();
+        let file_name = file.name_as_child().unwrap();
         assert_eq!(file_name, std::path::PathBuf::from("test.txt"));
 
         let mut data = Vec::new();

--- a/tests/zip_crypto.rs
+++ b/tests/zip_crypto.rs
@@ -75,7 +75,7 @@ fn encrypted_file() {
             .by_index_decrypt(0, "test".as_bytes())
             .unwrap()
             .unwrap();
-        let file_name = file.name_as_child().unwrap();
+        let file_name = file.enclosed_name().unwrap();
         assert_eq!(file_name, std::path::PathBuf::from("test.txt"));
 
         let mut data = Vec::new();


### PR DESCRIPTION
Closes #181

I've kept the old behaviour available through `mangled_name`, for users who actively decided on it. I took the opportunity to give a stronger warning in the documentation, and provide an alternative which I think is more suitable.

This also means we can bring back the `ZipArchive::extract` API, which I now see as effectively complete for 0.5.

Are these API changes enough @jamesmcm ?

(And since you've shown interest in the old API, I'd also like to know which strategy you prefer @aspen 😀 )