### PR TITLE
Update bzip2 requirement from 0.3 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 flate2 = { version = ">=1.0.0, <=1.0.14", default-features = false, optional = true }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"
-bzip2 = { version = "0.3", optional = true }
+bzip2 = { version = "0.4", optional = true }
 crc32fast = "1.0"
 thiserror = "1.0"
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -447,7 +447,7 @@ impl<W: Write + io::Seek> GenericZipWriter<W> {
                 )),
                 #[cfg(feature = "bzip2")]
                 CompressionMethod::Bzip2 => {
-                    GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::Default))
+                    GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::default()))
                 }
                 CompressionMethod::Unsupported(..) => {
                     return Err(ZipError::UnsupportedArchive("Unsupported compression"))


### PR DESCRIPTION
In 0.4, bzip2 changed to be API-compatible with flate2.

This should obsolete #174.