### PR TITLE
Support symbolic links

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -229,7 +229,7 @@ fn create_link(link_target: Vec<u8>, link_path: &Path) -> ZipResult<()> {
     #[cfg(target_family = "windows")]
     {
         // TODO: Support non-UTF-8 paths (currently only works for paths which are valid UTF-8)
-        let link_path = String::from_utf8(contents)?;
+        let link_target = String::from_utf8(link_target)?;
         std::os::windows::fs::symlink_file(link_target, link_path)?;
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -229,6 +229,11 @@ fn create_link(link_target: Vec<u8>, link_path: &Path) -> ZipResult<()> {
     Ok(())
 }
 
+#[cfg(target_family = "windows")]
+fn create_link(_link_target: Vec<u8>, _link_path: &Path) -> ZipResult<()> {
+    Ok(())
+}
+
 impl<R: Read + io::Seek> ZipArchive<R> {
     /// Get the directory start offset and number of files. This is done in a
     /// separate function to ease the control flow design.

--- a/src/read.rs
+++ b/src/read.rs
@@ -226,12 +226,12 @@ fn create_link(link_target: Vec<u8>, link_path: &Path) -> ZipResult<()> {
         let link_target = std::ffi::OsString::from_vec(link_target);
         std::os::unix::fs::symlink(link_target, link_path)?;
     }
-    #[cfg(target_family = "windows")]
-    {
-        // TODO: Support non-UTF-8 paths (currently only works for paths which are valid UTF-8)
-        let link_target = String::from_utf8(link_target)?;
-        std::os::windows::fs::symlink_file(link_target, link_path)?;
-    }
+    // #[cfg(target_family = "windows")]
+    // {
+    //     // TODO: Support non-UTF-8 paths (currently only works for paths which are valid UTF-8)
+    //     let link_target = String::from_utf8(link_target)?;
+    //     std::os::windows::fs::symlink_file(link_target, link_path)?;
+    // }
 
     Ok(())
 }


### PR DESCRIPTION
This is to resolve #77 

This probably needs some re-work - but hopefully this is the correct direction.

I am definitely open to design changes/feedback.

Questions:
* Should we create symbolic links on Windows - or just make a copy of the file?
  * If yes - what is the best way to convert the `Vec<u8>` to a valid `&Path`
* I am unclear how to test (the other tests don't seem to actually extract - which would be required to test this). Maybe I need to restructure for testing?
* Do I have terminology of "source"/"target" consistent (i.e. should I rename `get_symlink_source()` to `get_symlink_target()`?)

I have disabled symlink creation on windows. I can't find/google a way create a `Path`/`OsStr` from a `Vec<u8>`. I was going through String first - but then was running into the issue that the conversion error is not handled as part of `ZipError` (and it also seems wrong anyway). 
1. Going through String seems wrong to me - as Windows like Linux can support non-UTF-8 paths (so code for Zip file handling shouldn't really expect that paths are valid UTF-8)
2. If we decide to use this (using String) for now then should we add a new error type to `ZipError`?

