### PR TITLE
Support append to an existing archive

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -209,7 +209,7 @@ fn make_reader<'a>(
 impl<R: Read + io::Seek> ZipArchive<R> {
     /// Get the directory start offset and number of files. This is done in a
     /// separate function to ease the control flow design.
-    fn get_directory_counts(
+    pub fn get_directory_counts(
         reader: &mut R,
         footer: &spec::CentralDirectoryEnd,
         cde_start_pos: u64,
@@ -514,7 +514,8 @@ fn unsupported_zip_error<T>(detail: &'static str) -> ZipResult<T> {
     Err(ZipError::UnsupportedArchive(detail))
 }
 
-fn central_header_to_zip_file<R: Read + io::Seek>(
+/// Parse a central directory entry to collect the information for the file.
+pub fn central_header_to_zip_file<R: Read + io::Seek>(
     reader: &mut R,
     archive_offset: u64,
 ) -> ZipResult<ZipFileData> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -209,7 +209,7 @@ fn make_reader<'a>(
 impl<R: Read + io::Seek> ZipArchive<R> {
     /// Get the directory start offset and number of files. This is done in a
     /// separate function to ease the control flow design.
-    pub fn get_directory_counts(
+    pub(crate) fn get_directory_counts(
         reader: &mut R,
         footer: &spec::CentralDirectoryEnd,
         cde_start_pos: u64,
@@ -515,7 +515,7 @@ fn unsupported_zip_error<T>(detail: &'static str) -> ZipResult<T> {
 }
 
 /// Parse a central directory entry to collect the information for the file.
-pub fn central_header_to_zip_file<R: Read + io::Seek>(
+pub(crate) fn central_header_to_zip_file<R: Read + io::Seek>(
     reader: &mut R,
     archive_offset: u64,
 ) -> ZipResult<ZipFileData> {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -46,6 +46,25 @@ fn copy() {
     check_zip_file_contents(&mut tgt_archive, COPY_ENTRY_NAME);
 }
 
+// This test asserts that after appending to a `ZipWriter`, then reading its contents back out,
+// both the prior data and the appended data will be exactly the same as their originals.
+#[test]
+fn append() {
+    let mut file = &mut Cursor::new(Vec::new());
+    write_to_zip(file).expect("file written");
+
+    {
+        let mut zip = zip::ZipWriter::new_append(&mut file).unwrap();
+        zip.start_file(COPY_ENTRY_NAME, Default::default()).unwrap();
+        zip.write_all(LOREM_IPSUM).unwrap();
+        zip.finish().unwrap();
+    }
+
+    let mut zip = zip::ZipArchive::new(&mut file).unwrap();
+    check_zip_file_contents(&mut zip, ENTRY_NAME);
+    check_zip_file_contents(&mut zip, COPY_ENTRY_NAME);
+}
+
 fn write_to_zip(file: &mut Cursor<Vec<u8>>) -> zip::result::ZipResult<()> {
     let mut zip = zip::ZipWriter::new(file);
 


### PR DESCRIPTION
The implementation provides an alternative constructor, `new_append`, for `ZipWriter`, that takes a read-write buffer of existing archive and make it possible to add files to it.

`new_append` is mostly a copy of the `ZipArchive` constructor. It parses the central directory for the file list, and then set the cursor to the beginning of central directory in order to overwrite it. Users are expected to use the `ZipWriter` in the same way as if it is constructed from an empty buffer. When `finish` is called, the new central directory added will contains information for all prior files along with the appended files.

As the central directory parsing is borrowed from `ZipArchive`'s internal implementation, I need to make  `ZipArchive ::get_directory_counts` and `central_header_to_zip_file` public, which looks awkward to me. Is there a more graceful way? Also, suggestions on a better name for the constructor `new_append` are welcome.