### PR TITLE
Allow flate2 >1.0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
-# FIXME(#170): flate2 1.0.15 has an MSRV of 1.36.0, breaking ours. We'll update when we know if this will be addressed
-flate2 = { version = ">=1.0.0, <=1.0.14", default-features = false, optional = true }
+flate2 = { version = "1.0.0", default-features = false, optional = true }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"
 bzip2 = { version = "0.3", optional = true }


### PR DESCRIPTION
`flate2` was pinned to versions <= 1.0.14 in #175, because `flate2` 1.0.15 updated to `miniz_oxide` 0.4, which accidentally increased its MSRV (#170, Frommi/miniz_oxide#85).

This was fixed in `miniz_oxide` 0.4.2 (Frommi/miniz_oxide#95), so all published versions of `flate2` can once again be built with Rust 1.34.0.

Note: Since `flate2` still has a more lax MSRV policy than `zip`, we *could* make a more conservative change that limits the dependency to versions that are known to work on Rust 1.34:

```diff
-flate2 = { version = "1.0.0, <=1.0.14", default-features = false, optional = true }
+flate2 = { version = "1.0.0, <=1.0.20", default-features = false, optional = true }
```

However, I think it would be better, if this breaks again in the future, to fix CI builds by checking in or generating a `Cargo.lock` file for use in MSRV testing.