### PR TITLE
Remove `io::Read + io::Seek` bound to `ZipArchive`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -47,7 +47,7 @@ mod ffi {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct ZipArchive<R: Read + io::Seek> {
+pub struct ZipArchive<R> {
     reader: R,
     files: Vec<ZipFileData>,
     names_map: HashMap<String, usize>,


### PR DESCRIPTION
This is more in line with what is usually done and easier to use for downstream users.