### PR TITLE
Add method for writing files with raw byte filenames.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -97,14 +97,14 @@ impl MaybeUtf8 {
     pub fn as_bytes(&self) -> &[u8] {
         match *self {
             MaybeUtf8::Utf8(ref string) => string.as_bytes(),
-            MaybeUtf8::Raw(ref bytes) => &bytes,
+            MaybeUtf8::Raw(ref bytes) => bytes,
         }
     }
 
     pub fn to_string_lossy(&self) -> Cow<str> {
         match *self {
             MaybeUtf8::Utf8(ref string) => string.into(),
-            MaybeUtf8::Raw(ref bytes) => String::from_utf8_lossy(&bytes),
+            MaybeUtf8::Raw(ref bytes) => String::from_utf8_lossy(bytes),
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1067,11 +1067,9 @@ fn write_local_file_header<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipR
     writer.write_u32::<LittleEndian>(spec::LOCAL_FILE_HEADER_SIGNATURE)?;
     // version needed to extract
     writer.write_u16::<LittleEndian>(file.version_needed())?;
-    // general purpose bit flag
-    let flag = if !std::str::from_utf8(&file.file_name_raw)
-        .unwrap_or("あ")
-        .is_ascii()
-    {
+    // "General Purpose" bit flag.  When set, indicates that the
+    // name is utf8 compatible (either ascii or utf8-encoded unicode).
+    let flag = if !std::str::from_utf8(&file.file_name_raw).is_ok() {
         1u16 << 11
     } else {
         0

--- a/src/write.rs
+++ b/src/write.rs
@@ -429,7 +429,8 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         }
         *options.permissions.as_mut().unwrap() |= 0o100000;
         self.start_entry(name.into().as_bytes(), options, None)?;
-        self.inner.switch_to(options.compression_method, options.compression_level)?;
+        self.inner
+            .switch_to(options.compression_method, options.compression_level)?;
         self.writing_to_file = true;
         Ok(())
     }
@@ -1145,11 +1146,9 @@ fn write_central_directory_header<T: Write>(writer: &mut T, file: &ZipFileData) 
     writer.write_u16::<LittleEndian>(version_made_by)?;
     // version needed to extract
     writer.write_u16::<LittleEndian>(file.version_needed())?;
-    // general puprose bit flag
-    let flag = if !std::str::from_utf8(&file.file_name_raw)
-        .unwrap_or("あ")
-        .is_ascii()
-    {
+    // "General Purpose" bit flag.  When set, indicates that the
+    // name is utf8 compatible (either ascii or utf8-encoded unicode).
+    let flag = if !std::str::from_utf8(&file.file_name_raw).is_ok() {
         1u16 << 11
     } else {
         0

--- a/src/write.rs
+++ b/src/write.rs
@@ -429,8 +429,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         }
         *options.permissions.as_mut().unwrap() |= 0o100000;
         self.start_entry(name.into().as_bytes(), options, None)?;
-        self.inner
-            .switch_to(options.compression_method, options.compression_level)?;
+        self.inner.switch_to(options.compression_method, options.compression_level)?;
         self.writing_to_file = true;
         Ok(())
     }
@@ -1072,7 +1071,7 @@ fn write_local_file_header<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipR
     writer.write_u16::<LittleEndian>(file.version_needed())?;
     // "General Purpose" bit flag.  When set, indicates that the
     // name is utf8 compatible (either ascii or utf8-encoded unicode).
-    let flag = if !std::str::from_utf8(&file.file_name_raw).is_ok() {
+    let flag = if std::str::from_utf8(&file.file_name_raw).is_ok() {
         1u16 << 11
     } else {
         0
@@ -1148,7 +1147,7 @@ fn write_central_directory_header<T: Write>(writer: &mut T, file: &ZipFileData) 
     writer.write_u16::<LittleEndian>(file.version_needed())?;
     // "General Purpose" bit flag.  When set, indicates that the
     // name is utf8 compatible (either ascii or utf8-encoded unicode).
-    let flag = if !std::str::from_utf8(&file.file_name_raw).is_ok() {
+    let flag = if std::str::from_utf8(&file.file_name_raw).is_ok() {
         1u16 << 11
     } else {
         0

--- a/src/write.rs
+++ b/src/write.rs
@@ -429,12 +429,14 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         }
         *options.permissions.as_mut().unwrap() |= 0o100000;
         self.start_entry(name.into().as_bytes(), options, None)?;
-        self.inner.switch_to(options.compression_method)?;
+        self.inner.switch_to(options.compression_method, options.compression_level)?;
         self.writing_to_file = true;
         Ok(())
     }
 
-    /// Create a file in the archive with a raw-bytes-name and start writing its contents.
+    /// Create a file in the archive with a raw-bytes name and start writing its contents.
+    ///
+    /// Note: when your file name is valid utf8, prefer using `start_file()`.
     ///
     /// The data should be written using the [`io::Write`] implementation on this [`ZipWriter`]
     pub fn start_file_raw_name(&mut self, name: &[u8], mut options: FileOptions) -> ZipResult<()> {
@@ -792,7 +794,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         // likely wastes space. So always store.
         options.compression_method = CompressionMethod::Stored;
 
-        self.start_entry(name, options, None)?;
+        self.start_entry(name.into().as_bytes(), options, None)?;
         self.writing_to_file = true;
         self.write_all(target.into().as_bytes())?;
         self.writing_to_file = false;


### PR DESCRIPTION
This allows handling e.g. properly round-tripping zip files with contents that have non-utf8 filepaths.

I ran into this with a tool I'm writing, that specifically needs to work with zip files that contain alternative filename encodings, both reading and writing.  It's admittedly a little niche, but it does come up occasionally, and seems easy enough to accommodate.