### PR TITLE
Add Zstandard compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.3"
 bzip2 = { version = "0.4", optional = true }
 crc32fast = "1.0"
 thiserror = "1.0"
+zstd = { version = "0.8", optional = true }
 
 [dev-dependencies]
 bencher = "0.1"
@@ -28,7 +29,7 @@ deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
 deflate-zlib = ["flate2/zlib"]
 unreserved = []
-default = ["bzip2", "deflate", "time"]
+default = ["bzip2", "deflate", "time", "zstd"]
 
 [[bench]]
 name = "read_entry"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported compression formats:
 * stored (i.e. none)
 * deflate
 * bzip2
+* zstd (in progress...)
 
 Currently unsupported zip extensions:
 
@@ -42,9 +43,10 @@ zip = { version = "0.5", default-features = false }
 
 The features available are:
 
-* `deflate`: Enables the deflate compression algorithm, which is the default for zipfiles
+* `deflate`: Enables the deflate compression algorithm, which is the default for zipfiles.
 * `bzip2`: Enables the BZip2 compression algorithm.
 * `time`: Enables features using the [time](https://github.com/rust-lang-deprecated/time) crate.
+* `zstd`: Enables the Zstandard compression algorithm.
 
 All of these are enabled by default.
 

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -32,6 +32,11 @@ const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod
 #[cfg(not(feature = "bzip2"))]
 const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
 
+#[cfg(feature = "zstd")]
+const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
+#[cfg(not(feature = "zstd"))]
+const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
+
 fn real_main() -> i32 {
     let args: Vec<_> = std::env::args().collect();
     if args.len() < 3 {
@@ -44,7 +49,7 @@ fn real_main() -> i32 {
 
     let src_dir = &*args[1];
     let dst_file = &*args[2];
-    for &method in [METHOD_STORED, METHOD_DEFLATED, METHOD_BZIP2].iter() {
+    for &method in [METHOD_STORED, METHOD_DEFLATED, METHOD_BZIP2, METHOD_ZSTD].iter() {
         if method.is_none() {
             continue;
         }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -24,6 +24,9 @@ pub enum CompressionMethod {
     /// Compress the file using BZIP2
     #[cfg(feature = "bzip2")]
     Bzip2,
+    /// Compress the file using ZStandard
+    #[cfg(feature = "zstd")]
+    Zstd,
     /// Unsupported compression method
     #[deprecated(since = "0.5.7", note = "use the constants instead")]
     Unsupported(u16),
@@ -60,6 +63,9 @@ impl CompressionMethod {
     pub const IBM_ZOS_CMPSC: Self = CompressionMethod::Unsupported(16);
     pub const IBM_TERSE: Self = CompressionMethod::Unsupported(18);
     pub const ZSTD_DEPRECATED: Self = CompressionMethod::Unsupported(20);
+    #[cfg(feature = "zstd")]
+    pub const ZSTD: Self = CompressionMethod::Zstd;
+    #[cfg(not(feature = "zstd"))]
     pub const ZSTD: Self = CompressionMethod::Unsupported(93);
     pub const MP3: Self = CompressionMethod::Unsupported(94);
     pub const XZ: Self = CompressionMethod::Unsupported(95);
@@ -85,6 +91,8 @@ impl CompressionMethod {
             8 => CompressionMethod::Deflated,
             #[cfg(feature = "bzip2")]
             12 => CompressionMethod::Bzip2,
+            #[cfg(feature = "zstd")]
+            93 => CompressionMethod::Zstd,
 
             v => CompressionMethod::Unsupported(v),
         }
@@ -107,6 +115,9 @@ impl CompressionMethod {
             CompressionMethod::Deflated => 8,
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => 12,
+            #[cfg(feature = "zstd")]
+            CompressionMethod::Zstd => 93,
+
             CompressionMethod::Unsupported(v) => v,
         }
     }
@@ -145,6 +156,9 @@ mod test {
         methods.push(CompressionMethod::Deflated);
         #[cfg(feature = "bzip2")]
         methods.push(CompressionMethod::Bzip2);
+        #[cfg(feature = "zstd")]
+        methods.push(CompressionMethod::Zstd);
+
         methods
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -24,6 +24,9 @@ use flate2::read::DeflateDecoder;
 #[cfg(feature = "bzip2")]
 use bzip2::read::BzDecoder;
 
+#[cfg(feature = "zstd")]
+use zstd::stream::read::Decoder as ZstdDecoder;
+
 mod ffi {
     pub const S_IFDIR: u32 = 0o0040000;
     pub const S_IFREG: u32 = 0o0100000;
@@ -90,6 +93,8 @@ enum ZipFileReader<'a> {
     Deflated(Crc32Reader<flate2::read::DeflateDecoder<CryptoReader<'a>>>),
     #[cfg(feature = "bzip2")]
     Bzip2(Crc32Reader<BzDecoder<CryptoReader<'a>>>),
+    #[cfg(feature = "zstd")]
+    Zstd(Crc32Reader<ZstdDecoder<'a, io::BufReader<CryptoReader<'a>>>>),
 }
 
 impl<'a> Read for ZipFileReader<'a> {
@@ -106,6 +111,8 @@ impl<'a> Read for ZipFileReader<'a> {
             ZipFileReader::Deflated(r) => r.read(buf),
             #[cfg(feature = "bzip2")]
             ZipFileReader::Bzip2(r) => r.read(buf),
+            #[cfg(feature = "zstd")]
+            ZipFileReader::Zstd(r) => r.read(buf),
         }
     }
 }
@@ -125,6 +132,8 @@ impl<'a> ZipFileReader<'a> {
             ZipFileReader::Deflated(r) => r.into_inner().into_inner().into_inner(),
             #[cfg(feature = "bzip2")]
             ZipFileReader::Bzip2(r) => r.into_inner().into_inner().into_inner(),
+            #[cfg(feature = "zstd")]
+            ZipFileReader::Zstd(r) => r.into_inner().finish().into_inner().into_inner(),
         }
     }
 }
@@ -209,6 +218,11 @@ fn make_reader<'a>(
         CompressionMethod::Bzip2 => {
             let bzip2_reader = BzDecoder::new(reader);
             ZipFileReader::Bzip2(Crc32Reader::new(bzip2_reader, crc32))
+        }
+        #[cfg(feature = "zstd")]
+        CompressionMethod::Zstd => {
+            let zstd_reader = ZstdDecoder::new(reader).unwrap();
+            ZipFileReader::Zstd(Crc32Reader::new(zstd_reader, crc32))
         }
         _ => panic!("Compression method not supported"),
     }


### PR DESCRIPTION
Hi, this PR adds support for Zstandard/Zstd compression. I have only implemented support for method code 93, although Zstd was previously listed as code 20 (deprecated as of APPNOTE 6.3.8.)

I have created some archives with using the `write_dir` example and extracted them with the tools listed below. I've also created some archives with 7-zip-zstd and extracted them using the `extract` example. I have not noticed any issues so far, but I also haven't found any zstd compressed archives from the wild to test, so any links would be appreciated.

Tested with:
- https://github.com/jinfeihan57/p7zip
- https://github.com/mcmilk/7-Zip-zstd