### PR TITLE
chore: bump rand to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bencher = "0.1"
-rand = "0.7"
+rand = "0.8"
 walkdir = "2"
 
 [features]


### PR DESCRIPTION
The Minimum Supported Rust Version of rand 0.8 is rustc 1.36, which is exactly the MSRV of zip. Therefore, this should be safe to bump.