### PR TITLE
Use getrandom instead of rand for benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bencher = "0.1"
-rand = "0.7"
+getrandom = "0.2"
 walkdir = "2"
 
 [features]

--- a/benches/read_entry.rs
+++ b/benches/read_entry.rs
@@ -3,7 +3,7 @@ use bencher::{benchmark_group, benchmark_main};
 use std::io::{Cursor, Read, Write};
 
 use bencher::Bencher;
-use rand::Rng;
+use getrandom::getrandom;
 use zip::{ZipArchive, ZipWriter};
 
 fn generate_random_archive(size: usize) -> Vec<u8> {
@@ -14,7 +14,7 @@ fn generate_random_archive(size: usize) -> Vec<u8> {
 
     writer.start_file("random.dat", options).unwrap();
     let mut bytes = vec![0u8; size];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    getrandom(&mut bytes).unwrap();
     writer.write_all(&bytes).unwrap();
 
     writer.finish().unwrap().into_inner()


### PR DESCRIPTION
The current code didn’t build, and this one includes fewer dependencies than the full rand set of crates. This isn’t any slower from a quick benchmark on a Kaby Lake CPU, although I get a quite high variance in both cases.

Together with #250, this brings down the number of crates to build from 44 to 28.