### PR TITLE
feat: bump MSRV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable, 1.36.0]
+        rust: [stable, 1.54.0]
 
     steps:
     - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ All of these are enabled by default.
 MSRV
 ----
 
-Our current Minimum Supported Rust Version is **1.36.0**. When adding features,
+Our current Minimum Supported Rust Version is **1.54.0**. When adding features,
 we will follow these guidelines:
 
 - We will always support the latest four minor Rust versions. This gives you a 6


### PR DESCRIPTION
- update MSRV to 1.54 according to the policy. Seems like it needed for
  building dependencies properly
- update CI

Tested:
- No