### PR TITLE
fix: make zip-rs build on nightly compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ flate2 = { version = "1.0.0", default-features = false, optional = true }
 time = { version = "0.3", features = ["formatting", "macros" ], optional = true }
 byteorder = "1.3"
 bzip2 = { version = "0.4", optional = true }
-crc32fast = "1.0"
-thiserror = "1.0"
+crc32fast = "1.1.1"
+thiserror = "1.0.7"
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
- update dependencies for the compatibility with the nightly compiler

Tested:
- No