### PR TITLE
fix: remove extra CompressionMethod variant

### DIFF
--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -33,7 +33,7 @@ const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod
 const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
 
 #[cfg(feature = "zstd")]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
+const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::ZSTD);
 #[cfg(not(feature = "zstd"))]
 const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -24,9 +24,6 @@ pub enum CompressionMethod {
     /// Compress the file using BZIP2
     #[cfg(feature = "bzip2")]
     Bzip2,
-    /// Compress the file using ZStandard
-    #[cfg(feature = "zstd")]
-    Zstd,
     /// Unsupported compression method
     #[deprecated(since = "0.5.7", note = "use the constants instead")]
     Unsupported(u16),
@@ -63,9 +60,6 @@ impl CompressionMethod {
     pub const IBM_ZOS_CMPSC: Self = CompressionMethod::Unsupported(16);
     pub const IBM_TERSE: Self = CompressionMethod::Unsupported(18);
     pub const ZSTD_DEPRECATED: Self = CompressionMethod::Unsupported(20);
-    #[cfg(feature = "zstd")]
-    pub const ZSTD: Self = CompressionMethod::Zstd;
-    #[cfg(not(feature = "zstd"))]
     pub const ZSTD: Self = CompressionMethod::Unsupported(93);
     pub const MP3: Self = CompressionMethod::Unsupported(94);
     pub const XZ: Self = CompressionMethod::Unsupported(95);
@@ -92,7 +86,7 @@ impl CompressionMethod {
             #[cfg(feature = "bzip2")]
             12 => CompressionMethod::Bzip2,
             #[cfg(feature = "zstd")]
-            93 => CompressionMethod::Zstd,
+            20 | 93 => CompressionMethod::ZSTD,
 
             v => CompressionMethod::Unsupported(v),
         }
@@ -116,7 +110,7 @@ impl CompressionMethod {
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => 12,
             #[cfg(feature = "zstd")]
-            CompressionMethod::Zstd => 93,
+            CompressionMethod::ZSTD => 93,
 
             CompressionMethod::Unsupported(v) => v,
         }
@@ -157,7 +151,7 @@ mod test {
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2,
             #[cfg(feature = "zstd")]
-            CompressionMethod::Zstd,
+            CompressionMethod::ZSTD,
         ]
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -220,7 +220,7 @@ fn make_reader(
             ZipFileReader::Bzip2(Crc32Reader::new(bzip2_reader, crc32))
         }
         #[cfg(feature = "zstd")]
-        CompressionMethod::Zstd => {
+        CompressionMethod::ZSTD | CompressionMethod::ZSTD_DEPRECATED => {
             let zstd_reader = ZstdDecoder::new(reader).unwrap();
             ZipFileReader::Zstd(Crc32Reader::new(zstd_reader, crc32))
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -848,7 +848,7 @@ impl<W: Write + io::Seek> GenericZipWriter<W> {
                     GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::default()))
                 }
                 #[cfg(feature = "zstd")]
-                CompressionMethod::Zstd => {
+                CompressionMethod::ZSTD => {
                     GenericZipWriter::Zstd(ZstdEncoder::new(bare, 0).unwrap())
                 }
                 CompressionMethod::Unsupported(..) => {
@@ -900,7 +900,7 @@ impl<W: Write + io::Seek> GenericZipWriter<W> {
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(..) => Some(CompressionMethod::Bzip2),
             #[cfg(feature = "zstd")]
-            GenericZipWriter::Zstd(..) => Some(CompressionMethod::Zstd),
+            GenericZipWriter::Zstd(..) => Some(CompressionMethod::ZSTD),
             GenericZipWriter::Closed => None,
         }
     }


### PR DESCRIPTION
this is required to maintain backwards compatibility with 0.5

Closes #266 

I doubt these changes would introduce any problems themselves. @zamazan4ik, could you just check it's still well behaved with your zlib files? We'll add better tests before the release