### PR TITLE
Fix minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 aes = { version = "0.7.5", optional = true }
-byteorder = "1.3"
+byteorder = "1.3.4"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.1.1"
@@ -21,12 +21,12 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.10.0", optional = true }
 sha1 = {version = "0.10.0", optional = true }
 time = { version = "0.3.1", features = ["formatting", "macros" ], optional = true }
-zstd = { version = "0.10", optional = true }
+zstd = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
-bencher = "0.1"
-getrandom = "0.2"
-walkdir = "2"
+bencher = "0.1.5"
+getrandom = "0.2.5"
+walkdir = "2.3.2"
 
 [features]
 aes-crypto = [ "aes", "constant_time_eq", "hmac", "pbkdf2", "sha1" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ edition = "2018"
 
 [dependencies]
 aes = { version = "0.7.5", optional = true }
-byteorder = "1.3.4"
+byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
-crc32fast = "1.1.1"
-flate2 = { version = "1.0.13", default-features = false, optional = true }
+crc32fast = "1.3.2"
+flate2 = { version = "1.0.22", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
-pbkdf2 = {version = "0.10.0", optional = true }
-sha1 = {version = "0.10.0", optional = true }
-time = { version = "0.3.1", features = ["formatting", "macros" ], optional = true }
+pbkdf2 = {version = "0.10.1", optional = true }
+sha1 = {version = "0.10.1", optional = true }
+time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }
 zstd = { version = "0.10.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2018"
 [dependencies]
 aes = { version = "0.7.5", optional = true }
 byteorder = "1.3"
-bzip2 = { version = "0.4", optional = true }
+bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.1.1"
-flate2 = { version = "1.0.0", default-features = false, optional = true }
-hmac = { version = "0.12.0", optional = true, features = ["reset"] }
+flate2 = { version = "1.0.13", default-features = false, optional = true }
+hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.10.0", optional = true }
 sha1 = {version = "0.10.0", optional = true }
-time = { version = "0.3", features = ["formatting", "macros" ], optional = true }
+time = { version = "0.3.1", features = ["formatting", "macros" ], optional = true }
 zstd = { version = "0.10", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
As of latest master (a9e143665526a40cd8e1c194085644f7ec58f953) the code does not compile with `minimal-versions` and the default features:

```shell
cargo +nightly update -Z minimal-versions && cargo +nightly check
```

This PR contains 3 commits which build on each other such that:
- The 1st makes the minimal update to the versions in `Cargo.toml` such that all tests pass (with `--all-features`)
- The 2nd specifies precise versions for all dependancies in Cargo.toml
- The 3rd makes the maximal (breaking change) update to the versions in `Cargo.toml` such that all tests pass (with `--all-features`)