### PR TITLE
Fix targets without 64-bit atomics.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }
 zstd = { version = "0.10.0", optional = true }
 
+[target.'cfg(any(target_arch = "mips", target_arch = "powerpc"))'.dependencies]
+crossbeam-utils = "0.8.8"
+
 [dev-dependencies]
 bencher = "0.1.5"
 getrandom = "0.2.5"

--- a/src/read.rs
+++ b/src/read.rs
@@ -500,9 +500,9 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     }
 
     /// Search for a file entry by name, decrypt with given password
-    /// 
+    ///
     /// # Warning
-    /// 
+    ///
     /// The implementation of the cryptographic algorithms has not
     /// gone through a correctness review, and you should assume it is insecure:
     /// passwords used with this API may be compromised.
@@ -534,9 +534,9 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     }
 
     /// Get a contained file by index, decrypt with given password
-    /// 
+    ///
     /// # Warning
-    /// 
+    ///
     /// The implementation of the cryptographic algorithms has not
     /// gone through a correctness review, and you should assume it is insecure:
     /// passwords used with this API may be compromised.


### PR DESCRIPTION
Fixes #284. As soon as `MSRV >= 1.60.0` we might use [`target_has_atomic = "64"`](https://github.com/rust-lang/rust/pull/94817/files) instead of `target_arch`.