### PR TITLE
Add support for specifying compression level

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -500,9 +500,9 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     }
 
     /// Search for a file entry by name, decrypt with given password
-    /// 
+    ///
     /// # Warning
-    /// 
+    ///
     /// The implementation of the cryptographic algorithms has not
     /// gone through a correctness review, and you should assume it is insecure:
     /// passwords used with this API may be compromised.
@@ -534,9 +534,9 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     }
 
     /// Get a contained file by index, decrypt with given password
-    /// 
+    ///
     /// # Warning
-    /// 
+    ///
     /// The implementation of the cryptographic algorithms has not
     /// gone through a correctness review, and you should assume it is insecure:
     /// passwords used with this API may be compromised.
@@ -679,6 +679,7 @@ pub(crate) fn central_header_to_zip_file<R: Read + io::Seek>(
             #[allow(deprecated)]
             CompressionMethod::from_u16(compression_method)
         },
+        compression_level: None,
         last_modified_time: DateTime::from_msdos(last_mod_date, last_mod_time),
         crc32,
         compressed_size: compressed_size as u64,
@@ -1074,6 +1075,7 @@ pub fn read_zipfile_from_stream<'a, R: io::Read>(
         encrypted,
         using_data_descriptor,
         compression_method,
+        compression_level: None,
         last_modified_time: DateTime::from_msdos(last_mod_date, last_mod_time),
         crc32,
         compressed_size: compressed_size as u64,

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,6 +265,8 @@ pub struct ZipFileData {
     pub using_data_descriptor: bool,
     /// Compression method used to store the file
     pub compression_method: crate::compression::CompressionMethod,
+    /// Compression level to store the file
+    pub compression_level: Option<i32>,
     /// Last modified time. This will only have a 2 second precision.
     pub last_modified_time: DateTime,
     /// CRC32 checksum
@@ -396,6 +398,7 @@ mod test {
             encrypted: false,
             using_data_descriptor: false,
             compression_method: crate::compression::CompressionMethod::Stored,
+            compression_level: None,
             last_modified_time: DateTime::default(),
             crc32: 0,
             compressed_size: 0,


### PR DESCRIPTION
Hi,

I've been using zip-rs to compress somewhat large files on the fly.
Setting compression level from 6 (the default) to 1 makes a big difference in time to compress (about ~3-fold reduction).

In #212 some concerns regarding API compatibility were raised, but I don't see any concerns: field is added to ZipFileData which is not exported from the crate.

I also don't like using u32 to specify compression level (without range checking) - but it seems that flate2, bzip and zstd also use u32.