### PR TITLE
Use Seek.stream_position instead of seek(0).

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -639,7 +639,7 @@ pub(crate) fn central_header_to_zip_file<R: Read + io::Seek>(
     reader: &mut R,
     archive_offset: u64,
 ) -> ZipResult<ZipFileData> {
-    let central_header_start = reader.seek(io::SeekFrom::Current(0))?;
+    let central_header_start = reader.stream_position()?;
     // Parse central header
     let signature = reader.read_u32::<LittleEndian>()?;
     if signature != spec::CENTRAL_DIRECTORY_HEADER_SIGNATURE {


### PR DESCRIPTION
BufReader can cache the result of stream_position() so it's fast, whereas seek(0) discards the read buffer and passes through straight to the OS. This drastically worsens the efficiency of loading performance when using BufReader (or anything else to avoid all these tiny reads going straight to the kernel).