### PR TITLE
Annotate why some crypto dependencies can't be upgraded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
+# 0.8 requires 2021 edition and MSRV >=1.56.
 aes = { version = "0.7.5", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
+# 0.2 requires 2021 edition and MSRV >=1.56.
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.22", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
+# 0.11 requires 2021 edition and MSRV >=1.56.
 pbkdf2 = {version = "0.10.1", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }


### PR DESCRIPTION
I found myself in dependency hell related to a bunch of RustCrypto
crates and have been chasing down intermediate dependencies.

It looks like we can't upgrade these dependencies in zip-rs because
of the current 1.54.0 MSRV. I figured I'd leave comments in the
Cargo.toml so others are aware.

While I'm here, is there any appetite in bumping the MSRV to 1.56 so we
can upgrade these crates? It can be exceptionally difficult to adopt the latest
versions of crates under the RustCrypto umbrella because some of these crates
are very widely used. I could probably code up a PR. Let me know...