### PR TITLE
Add read fuzzing module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,3 +74,19 @@ jobs:
 
     - name: Docs
       run: cargo doc
+
+  fuzz:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - run: cargo install cargo-fuzz
+      - name: compile fuzz
+        run: |
+          cargo fuzz build fuzz_read

--- a/README.md
+++ b/README.md
@@ -75,3 +75,24 @@ See the [examples directory](examples) for:
    * How to extract a zip file.
    * How to extract a single file from a zip.
    * How to read a zip from the standard input.
+
+Fuzzing
+-------
+
+Fuzzing support is through [cargo fuzz](https://github.com/rust-fuzz/cargo-fuzz). To install cargo fuzz:
+
+```bash
+cargo install cargo-fuzz
+```
+
+To list fuzz targets:
+
+```bash
+cargo +nightly fuzz list
+```
+
+To start fuzzing zip extraction:
+
+```bash
+cargo +nightly fuzz run fuzz_read
+```

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "zip-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.zip]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_read"
+path = "fuzz_targets/fuzz_read.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_read.rs
+++ b/fuzz/fuzz_targets/fuzz_read.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fn decompress_all(data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    let reader = std::io::Cursor::new(data);
+    let mut zip = zip::ZipArchive::new(reader)?;
+
+    for i in 0..zip.len() {
+        let mut file = zip.by_index(i)?;
+        if file.size() < 1 << 20 {
+            let _ = std::io::copy(&mut file, &mut std::io::sink());
+        }
+    }
+
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = decompress_all(data);
+});


### PR DESCRIPTION
As someone who has personal projects that take untrusted zips as input,
it is important to me to be able to fuzz the zip project to simulate
possible inputs and to ensure the projects are not vulnerable.

This commit adds a cargo fuzz module for reading and extracting input.

The `fuzz` directory was scaffolded with a `cargo fuzz init`

I added a CI step to guard against the fuzz module decaying over time.