### PR TITLE
bump MSRV to 1.57

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable, 1.54.0]
+        rust: [stable, 1.57.0]
 
     steps:
     - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All of these are enabled by default.
 MSRV
 ----
 
-Our current Minimum Supported Rust Version is **1.54.0**. When adding features,
+Our current Minimum Supported Rust Version is **1.57.0**. When adding features,
 we will follow these guidelines:
 
 - We will always support the latest four minor Rust versions. This gives you a 6


### PR DESCRIPTION
This PR bumps the MSRV to 1.57, as suggested in https://github.com/zip-rs/zip/pull/306#issuecomment-1100830105 by @zamazan4ik.

> since our MSRV prevents updating our dependencies AND our MSRV policy says about support only about 4 latest minor versions, I suggest you just create a PR with bumping a MSRV version to 1.57 (1.57, 1.58, 1.59, 1.60 - is fine).