### PR TITLE
chore: update dependencies (pbkdf2 0.11.0, flate2 1.0.23)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
-flate2 = { version = "1.0.22", default-features = false, optional = true }
+flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
-pbkdf2 = {version = "0.10.1", optional = true }
+pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }
 zstd = { version = "0.11.0", optional = true }


### PR DESCRIPTION
This is a follow up to #310 and the now closed #306.

It gets the dependencies closer to what #306 _presumably_ would have been, had the MSRV already been at 1.57 when that PR was opened.