### PR TITLE
Depend Fix [zstd]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable, 1.57.0]
+        rust: [stable, 1.59.0]
 
     steps:
     - uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }
-zstd = { version = "0.11.0", optional = true }
+zstd = { version = "0.11", optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.8"

--- a/src/read.rs
+++ b/src/read.rs
@@ -461,7 +461,7 @@ impl<R: Read + io::Seek> ZipArchive<R> {
             } else {
                 if let Some(p) = outpath.parent() {
                     if !p.exists() {
-                        fs::create_dir_all(&p)?;
+                        fs::create_dir_all(p)?;
                     }
                 }
                 let mut outfile = fs::File::create(&outpath)?;
@@ -681,11 +681,11 @@ pub(crate) fn central_header_to_zip_file<R: Read + io::Seek>(
     reader.read_exact(&mut file_comment_raw)?;
 
     let file_name = match is_utf8 {
-        true => String::from_utf8_lossy(&*file_name_raw).into_owned(),
+        true => String::from_utf8_lossy(&file_name_raw).into_owned(),
         false => file_name_raw.clone().from_cp437(),
     };
     let file_comment = match is_utf8 {
-        true => String::from_utf8_lossy(&*file_comment_raw).into_owned(),
+        true => String::from_utf8_lossy(&file_comment_raw).into_owned(),
         false => file_comment_raw.from_cp437(),
     };
 
@@ -1085,7 +1085,7 @@ pub fn read_zipfile_from_stream<'a, R: io::Read>(
     reader.read_exact(&mut extra_field)?;
 
     let file_name = match is_utf8 {
-        true => String::from_utf8_lossy(&*file_name_raw).into_owned(),
+        true => String::from_utf8_lossy(&file_name_raw).into_owned(),
         false => file_name_raw.clone().from_cp437(),
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,7 +44,7 @@ mod atomic {
 #[cfg(feature = "time")]
 use time::{error::ComponentRange, Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum System {
     Dos = 0,
     Unix = 3,
@@ -143,10 +143,8 @@ impl DateTime {
         second: u8,
     ) -> Result<DateTime, ()> {
         if (1980..=2107).contains(&year)
-            && month >= 1
-            && month <= 12
-            && day >= 1
-            && day <= 31
+            && (1..=12).contains(&month)
+            && (1..=31).contains(&day)
             && hour <= 23
             && minute <= 59
             && second <= 60

--- a/src/write.rs
+++ b/src/write.rs
@@ -1301,7 +1301,7 @@ fn path_to_string(path: &std::path::Path) -> String {
             if !path_str.is_empty() {
                 path_str.push('/');
             }
-            path_str.push_str(&*os_str.to_string_lossy());
+            path_str.push_str(&os_str.to_string_lossy());
         }
     }
     path_str


### PR DESCRIPTION
when compiling with Actix web the exact version depend 0.11.0 creates a conflict with actix-web

By setting it to just 0.11 it can use any patch version of 0.11 so 0.11.0 or 0.11... 

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio