### PR TITLE
Add zstd-pkg-config feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
 deflate-zlib = ["flate2/zlib"]
 unreserved = []
+zstd-pkg-config = ["zstd/pkg-config"]
 default = ["aes-crypto", "bzip2", "deflate", "time", "zstd"]
 
 [[bench]]


### PR DESCRIPTION
This is so consumers of `zip` can use the `pkg-config` feature of `zstd` without manually adding a `zstd` dependency