### PR TITLE
Implement TryFrom<OffsetDateTime> for DateTime

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -84,17 +84,15 @@ impl From<ZipError> for io::Error {
 
 /// Error type for time parsing
 #[derive(Debug)]
-pub enum ZipDateTimeError {
-    /// The date was on or before 1980, or on or after 2107
-    DateTimeOutOfBounds,
-}
+pub struct DateTimeRangeError;
 
-impl fmt::Display for ZipDateTimeError {
+impl fmt::Display for DateTimeRangeError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ZipDateTimeError::DateTimeOutOfBounds => write!(fmt, "datetime out of bounds"),
-        }
+        write!(
+            fmt,
+            "a date could not be represented within the bounds the MS-DOS date range (1980-2107)"
+        )
     }
 }
 
-impl Error for ZipDateTimeError {}
+impl Error for DateTimeRangeError {}

--- a/src/result.rs
+++ b/src/result.rs
@@ -81,3 +81,20 @@ impl From<ZipError> for io::Error {
         io::Error::new(io::ErrorKind::Other, err)
     }
 }
+
+/// Error type for time parsing
+#[derive(Debug)]
+pub enum ZipDateTimeError {
+    /// The date was on or before 1980, or on or after 2107
+    DateTimeOutOfBounds,
+}
+
+impl fmt::Display for ZipDateTimeError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ZipDateTimeError::DateTimeOutOfBounds => write!(fmt, "datetime out of bounds"),
+        }
+    }
+}
+
+impl Error for ZipDateTimeError {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -511,20 +511,22 @@ mod test {
     #[cfg(feature = "time")]
     #[test]
     fn datetime_from_time_bounds() {
+        use std::convert::TryFrom;
+
         use super::DateTime;
         use time::macros::datetime;
 
         // 1979-12-31 23:59:59
-        assert!(DateTime::from_time(datetime!(1979-12-31 23:59:59 UTC)).is_err());
+        assert!(DateTime::try_from(datetime!(1979-12-31 23:59:59 UTC)).is_err());
 
         // 1980-01-01 00:00:00
-        assert!(DateTime::from_time(datetime!(1980-01-01 00:00:00 UTC)).is_ok());
+        assert!(DateTime::try_from(datetime!(1980-01-01 00:00:00 UTC)).is_ok());
 
         // 2107-12-31 23:59:59
-        assert!(DateTime::from_time(datetime!(2107-12-31 23:59:59 UTC)).is_ok());
+        assert!(DateTime::try_from(datetime!(2107-12-31 23:59:59 UTC)).is_ok());
 
         // 2108-01-01 00:00:00
-        assert!(DateTime::from_time(datetime!(2108-01-01 00:00:00 UTC)).is_err());
+        assert!(DateTime::try_from(datetime!(2108-01-01 00:00:00 UTC)).is_err());
     }
 
     #[cfg(feature = "time")]
@@ -601,7 +603,6 @@ mod test {
         // 2020-01-01 00:00:00
         let clock = OffsetDateTime::from_unix_timestamp(1_577_836_800).unwrap();
 
-        assert!(DateTime::from_time(clock).is_ok());
         assert!(DateTime::try_from(clock).is_ok());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@ use std::convert::{TryFrom, TryInto};
     target_arch = "powerpc"
 )))]
 use std::sync::atomic;
+#[cfg(not(feature = "time"))]
 use std::time::SystemTime;
 #[cfg(doc)]
 use {crate::read::ZipFile, crate::write::FileOptions};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Types that specify what is contained in a ZIP.
 #[cfg(feature = "time")]
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 #[cfg(not(any(
     all(target_arch = "arm", target_pointer_width = "32"),
     target_arch = "mips",
@@ -173,8 +173,6 @@ impl DateTime {
     #[allow(clippy::result_unit_err)]
     #[deprecated(note = "use `DateTime::try_from()`")]
     pub fn from_time(dt: OffsetDateTime) -> Result<DateTime, ()> {
-        use std::convert::TryInto;
-
         dt.try_into().map_err(|_err| ())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,18 +173,9 @@ impl DateTime {
     #[allow(clippy::result_unit_err)]
     #[deprecated(note = "use `DateTime::try_from()`")]
     pub fn from_time(dt: OffsetDateTime) -> Result<DateTime, ()> {
-        if dt.year() >= 1980 && dt.year() <= 2107 {
-            Ok(DateTime {
-                year: (dt.year()) as u16,
-                month: (dt.month()) as u8,
-                day: dt.day(),
-                hour: dt.hour(),
-                minute: dt.minute(),
-                second: dt.second(),
-            })
-        } else {
-            Err(())
-        }
+        use std::convert::TryInto;
+
+        dt.try_into().map_err(|_err| ())
     }
 
     /// Gets the time portion of this datetime in the msdos representation

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,7 +44,7 @@ mod atomic {
 }
 
 #[cfg(feature = "time")]
-use crate::result::ZipDateTimeError;
+use crate::result::DateTimeRangeError;
 #[cfg(feature = "time")]
 use time::{error::ComponentRange, Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
 
@@ -259,7 +259,7 @@ impl DateTime {
 
 #[cfg(feature = "time")]
 impl TryFrom<OffsetDateTime> for DateTime {
-    type Error = ZipDateTimeError;
+    type Error = DateTimeRangeError;
 
     fn try_from(dt: OffsetDateTime) -> Result<Self, Self::Error> {
         if dt.year() >= 1980 && dt.year() <= 2107 {
@@ -272,7 +272,7 @@ impl TryFrom<OffsetDateTime> for DateTime {
                 second: dt.second(),
             })
         } else {
-            Err(ZipDateTimeError::DateTimeOutOfBounds)
+            Err(DateTimeRangeError)
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -191,7 +191,7 @@ impl Default for FileOptions {
             compression_method: CompressionMethod::Stored,
             compression_level: None,
             #[cfg(feature = "time")]
-            last_modified_time: DateTime::from_time(OffsetDateTime::now_utc()).unwrap_or_default(),
+            last_modified_time: OffsetDateTime::now_utc().try_into().unwrap_or_default(),
             #[cfg(not(feature = "time"))]
             last_modified_time: DateTime::default(),
             permissions: None,

--- a/src/write.rs
+++ b/src/write.rs
@@ -7,6 +7,7 @@ use crate::spec;
 use crate::types::{AtomicU64, DateTime, System, ZipFileData, DEFAULT_VERSION};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
+use std::convert::TryInto;
 use std::default::Default;
 use std::io;
 use std::io::prelude::*;


### PR DESCRIPTION
This allows users to use try_into when converting `OffsetDateTime` into `DateTime` and deprecates the previous specialized method.