### PR TITLE
Disable `time` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.6.4] - unreleased
+
+### Changed
+
+ - [#333](https://github.com/zip-rs/zip/pull/333): disabled the default features of the `time` dependency, and also `formatting` and `macros`, as they were enabled by mistake.
+ 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
-time = { version = "0.3.7", features = ["formatting", "macros" ], optional = true }
+time = { version = "0.3.7", optional = true, default-features = false, features = ["std"] }
 zstd = { version = "0.11.2", optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
@@ -30,6 +30,7 @@ crossbeam-utils = "0.8.8"
 bencher = "0.1.5"
 getrandom = "0.2.5"
 walkdir = "2.3.2"
+time = { version = "0.3.7", features = ["formatting", "macros"] }
 
 [features]
 aes-crypto = [ "aes", "constant_time_eq", "hmac", "pbkdf2", "sha1" ]


### PR DESCRIPTION
I left these enabled in `dev-dependencies`, so that the tests still work, but to be honest, I don't think those tests are really useful.

The reason to disable this is the proc macro stuff has a significant build time impact, and it's not really something `zip` users need.