### PR TITLE
Add units to the size documentation

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -920,12 +920,12 @@ impl<'a> ZipFile<'a> {
         self.data.compression_method
     }
 
-    /// Get the size of the file in the archive
+    /// Get the size of the file, in bytes, in the archive
     pub fn compressed_size(&self) -> u64 {
         self.data.compressed_size
     }
 
-    /// Get the size of the file when uncompressed
+    /// Get the size of the file, in bytes, when uncompressed
     pub fn size(&self) -> u64 {
         self.data.uncompressed_size
     }


### PR DESCRIPTION
The documentation did not list what it meant by "size". I changed it to specify that it is returning the size in bytes.

The standard library fs module specifies that size is returned in bytes. I modified this documentation to match the style of the standard library. 

https://doc.rust-lang.org/std/fs/struct.Metadata.html#method.len
