### PR TITLE
Detect insufficient CentralDirectoryEnd record

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -348,7 +348,9 @@ impl<R: Read + io::Seek> ZipArchive<R> {
             Some(locator64) => {
                 // If we got here, this is indeed a ZIP64 file.
 
-                if footer.disk_number as u32 != locator64.disk_with_central_directory {
+                if !footer.record_too_small()
+                    && footer.disk_number as u32 != locator64.disk_with_central_directory
+                {
                     return unsupported_zip_error(
                         "Support for multi-disk files is not implemented",
                     );
@@ -401,7 +403,7 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     pub fn new(mut reader: R) -> ZipResult<ZipArchive<R>> {
         let (footer, cde_start_pos) = spec::CentralDirectoryEnd::find_and_parse(&mut reader)?;
 
-        if footer.disk_number != footer.disk_with_central_directory {
+        if !footer.record_too_small() && footer.disk_number != footer.disk_with_central_directory {
             return unsupported_zip_error("Support for multi-disk files is not implemented");
         }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -23,6 +23,18 @@ pub struct CentralDirectoryEnd {
 }
 
 impl CentralDirectoryEnd {
+    // Per spec 4.4.1.4 - a CentralDirectoryEnd field might be insufficient to hold the
+    // required data. In this case the file SHOULD contain a ZIP64 format record
+    // and the field of this record will be set to -1
+    pub(crate) fn record_too_small(&self) -> bool {
+        self.disk_number == 0xFFFF
+            || self.disk_with_central_directory == 0xFFFF
+            || self.number_of_files_on_this_disk == 0xFFFF
+            || self.number_of_files == 0xFFFF
+            || self.central_directory_size == 0xFFFFFFFF
+            || self.central_directory_offset == 0xFFFFFFFF
+    }
+
     pub fn parse<T: Read>(reader: &mut T) -> ZipResult<CentralDirectoryEnd> {
         let magic = reader.read_u32::<LittleEndian>()?;
         if magic != CENTRAL_DIRECTORY_END_SIGNATURE {


### PR DESCRIPTION
Per zip spec 4.4.1.4 (https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT)

>      4.4.1.4  If one of the fields in the end of central directory
>      record is too small to hold required data, the field SHOULD be 
>      set to -1 (0xFFFF or 0xFFFFFFFF) and the ZIP64 format record 
>      SHOULD be created.

Previously these archives were incorrectly detected as multi-disk.