### PR TITLE
Remove redundant tests

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -557,27 +557,6 @@ mod test {
 
     #[cfg(feature = "time")]
     #[test]
-    fn datetime_from_time_bounds() {
-        use std::convert::TryFrom;
-
-        use super::DateTime;
-        use time::macros::datetime;
-
-        // 1979-12-31 23:59:59
-        assert!(DateTime::try_from(datetime!(1979-12-31 23:59:59 UTC)).is_err());
-
-        // 1980-01-01 00:00:00
-        assert!(DateTime::try_from(datetime!(1980-01-01 00:00:00 UTC)).is_ok());
-
-        // 2107-12-31 23:59:59
-        assert!(DateTime::try_from(datetime!(2107-12-31 23:59:59 UTC)).is_ok());
-
-        // 2108-01-01 00:00:00
-        assert!(DateTime::try_from(datetime!(2108-01-01 00:00:00 UTC)).is_err());
-    }
-
-    #[cfg(feature = "time")]
-    #[test]
     fn datetime_try_from_bounds() {
         use std::convert::TryFrom;
 


### PR DESCRIPTION
Removing redundant tests. I had originally left in the old test with the original implementation, but since we change the implementation of `DateTime::from_time` we do not need these tests. (Especially now that they match the `datetime_try_from_bounds` tests.