### PR TITLE
update aes to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
-aes = { version = "0.7.5", optional = true }
+aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }

--- a/src/aes_ctr.rs
+++ b/src/aes_ctr.rs
@@ -2,10 +2,11 @@
 //!
 //! This was implemented since the zip specification requires the mode to not use a nonce and uses a
 //! different byte order (little endian) than NIST (big endian).
-//! See [AesCtrZipKeyStream](./struct.AesCtrZipKeyStream.html) for more information.
+//! See [AesCtrZipKeyStream] for more information.
 
 use aes::cipher::generic_array::GenericArray;
-use aes::{BlockEncrypt, NewBlockCipher};
+// use aes::{BlockEncrypt, NewBlockCipher};
+use aes::cipher::{BlockEncrypt, KeyInit};
 use byteorder::WriteBytesExt;
 use std::{any, fmt};
 
@@ -82,7 +83,7 @@ where
 impl<C> AesCtrZipKeyStream<C>
 where
     C: AesKind,
-    C::Cipher: NewBlockCipher,
+    C::Cipher: KeyInit,
 {
     /// Creates a new zip variant AES-CTR key stream.
     ///
@@ -150,14 +151,14 @@ fn xor(dest: &mut [u8], src: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::{Aes128, Aes192, Aes256, AesCipher, AesCtrZipKeyStream, AesKind};
-    use aes::{BlockEncrypt, NewBlockCipher};
+    use aes::cipher::{BlockEncrypt, KeyInit};
 
     /// Checks whether `crypt_in_place` produces the correct plaintext after one use and yields the
     /// cipertext again after applying it again.
     fn roundtrip<Aes>(key: &[u8], ciphertext: &mut [u8], expected_plaintext: &[u8])
     where
         Aes: AesKind,
-        Aes::Cipher: NewBlockCipher + BlockEncrypt,
+        Aes::Cipher: KeyInit + BlockEncrypt,
     {
         let mut key_stream = AesCtrZipKeyStream::<Aes>::new(key);
 


### PR DESCRIPTION
(hazard): The changelog in aes doesn't indicate any change in behaviour, and I have assumed the new APIs work identically

This closes #352. Lets check that the CI likes it.

@mbr! As the author of the original PR, would love your input here - do you think any more changes need to be made to support the newer `aes`?