### PR TITLE
Add rust-version field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = """
 Library to support the reading and writing of zip files.
 """
 edition = "2021"
+rust-version = "1.59.0"
 
 [dependencies]
 aes = { version = "0.7.5", optional = true }


### PR DESCRIPTION
This causes compilers older than the MSRV to produce a warning/error which more clearly indicates that the crate needs a newer compiler. See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field