### PR TITLE
Update bzip constraint to 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.59.0"
 [dependencies]
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
-bzip2 = { version = "0.4.3", optional = true }
+bzip2 = { version = "0.4.4", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)
