### PR TITLE
bump bzip2 to 0.4.4 to fix RUSTSEC-2023-0004 / CVE-2023-22895

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.59.0"
 [dependencies]
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
-bzip2 = { version = "0.4.3", optional = true }
+bzip2 = { version = "0.4.4", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }


### PR DESCRIPTION
This vulnerability is also known as GHSA-96jv-r488-c2rj.

Versions of the `bzip2` crate before 0.4.4 contain a Denial of Service vulnerability that could cause the compression and / or decompression to run into an infinite loop. For more details see <https://rustsec.org/advisories/RUSTSEC-2023-0004.html> or <https://github.com/alexcrichton/bzip2-rs/pull/86>.

**Edit:** @Plecra: You might want to merge #393 before this one to fix the build errors related to `clippy` and `rustfmt`.